### PR TITLE
Use a single host path for actualserver

### DIFF
--- a/actual-server.xml
+++ b/actual-server.xml
@@ -45,6 +45,5 @@ Client GitHub repo: https://github.com/actualbudget/actual | Server GitHub repo:
   <Environment/>
   <Labels/>
   <Config Name="Web UI" Target="5006" Default="5006" Mode="tcp" Description="Container Port: 5006" Type="Port" Display="always" Required="false" Mask="false">5006</Config>
-  <Config Name="Host Path 1" Target="/data/server-files" Default="/mnt/user/appdata/actual-server/server-files" Mode="rw" Description="" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/actual-server/server-files</Config>
-  <Config Name="Host Path 2" Target="/data/user-files" Default="/mnt/user/appdata/actual-server/user-files" Mode="rw" Description="" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/actual-server/user-files</Config>
+  <Config Name="Host Path" Target="/data" Default="/mnt/user/appdata/actual-server" Mode="rw" Description="" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/actual-server</Config>
 </Container>


### PR DESCRIPTION
Migrations were not persisted as these are saved in the data folder itself. 

With the most recent version they had a migration that could only be run once otherwise it would break, which it did for all users of this template.